### PR TITLE
Managers can audit transactions

### DIFF
--- a/backend/src/main/java/com/revature/project2/controllers/TransactionController.java
+++ b/backend/src/main/java/com/revature/project2/controllers/TransactionController.java
@@ -64,5 +64,18 @@ public class TransactionController {
         return ResponseEntity.ok(transactionService.getTransactionsByEnvelopeId(envelopeId));
     }
 
+    @PatchMapping("/transactions/audit/{id}")
+    public ResponseEntity<?> auditTransaction(@PathVariable Integer id) {
+        // Call the service layer to audit the transaction category and return the updated transaction
+        return ResponseEntity.ok(transactionService.setTransactionAuditStatus(id, true));
+    }
+
+    @PatchMapping("/transactions/unaudit/{id}")
+    public ResponseEntity<?> unauditTransaction(@PathVariable Integer id) {
+        // Call the service layer to unaudit the transaction category and return the updated transaction
+        return ResponseEntity.ok(transactionService.setTransactionAuditStatus(id, false));
+    }
+
+
 
 }

--- a/backend/src/main/java/com/revature/project2/models/Transaction.java
+++ b/backend/src/main/java/com/revature/project2/models/Transaction.java
@@ -31,6 +31,8 @@ public class Transaction {
     @JsonIgnore
     private List<EnvelopeHistory> envelopeHistories;
 
+    private boolean audited = false;
+
     public Transaction() {
     }
 
@@ -42,6 +44,18 @@ public class Transaction {
         this.datetime = datetime;
         this.category = category;
         this.transactionAmount = transactionAmount;
+    }
+
+    public Transaction(int transactionId, String title, String transactionDescription, Envelope envelope, LocalDateTime datetime, String category, double transactionAmount, List<EnvelopeHistory> envelopeHistories, boolean audited) {
+        this.transactionId = transactionId;
+        this.title = title;
+        this.transactionDescription = transactionDescription;
+        this.envelope = envelope;
+        this.datetime = datetime;
+        this.category = category;
+        this.transactionAmount = transactionAmount;
+        this.envelopeHistories = envelopeHistories;
+        this.audited = audited;
     }
 
     public int getTransactionId() {
@@ -106,6 +120,14 @@ public class Transaction {
 
     public void setEnvelopeHistories(List<EnvelopeHistory> envelopeHistories) {
         this.envelopeHistories = envelopeHistories;
+    }
+
+    public boolean isAudited() {
+        return audited;
+    }
+
+    public void setAudited(boolean audited) {
+        this.audited = audited;
     }
 
     @Override

--- a/backend/src/main/java/com/revature/project2/services/AuthenticationService.java
+++ b/backend/src/main/java/com/revature/project2/services/AuthenticationService.java
@@ -44,4 +44,20 @@ public class AuthenticationService {
                    .toList();
        return Optional.of(new AbstractMap.SimpleEntry<>(username,roles));
     }
+
+    // putting this code here as it should be a function of authentification
+    //
+    private boolean validateCurrentUserRole(String authorizedLevelRole){
+        // if no user in the context, just check for provided roles
+        var currentUser = getAuthenticatedUser();
+        if(currentUser.isEmpty()){
+            return true;
+        }
+        List<UserRoles> currentRoles = currentUser.get().getValue();
+
+        var authRole = UserRoles.valueOf(authorizedLevelRole.trim());
+        boolean isAuthRoleHigherThanAnyPresent = currentRoles.stream().allMatch(curRole->authRole.ordinal()>curRole.ordinal());
+        if(isAuthRoleHigherThanAnyPresent){return false;}
+        return true;
+    }
 }

--- a/backend/src/main/java/com/revature/project2/services/AuthenticationService.java
+++ b/backend/src/main/java/com/revature/project2/services/AuthenticationService.java
@@ -46,8 +46,9 @@ public class AuthenticationService {
     }
 
     // putting this code here as it should be a function of authentification
-    //
-    private boolean validateCurrentUserRole(String authorizedLevelRole){
+    // WARNING: works differnetly from source code.
+    // pass in the role you want to validate the current user against
+    public boolean validateCurrentUserRole(String authorizedLevelRole){
         // if no user in the context, just check for provided roles
         var currentUser = getAuthenticatedUser();
         if(currentUser.isEmpty()){
@@ -56,8 +57,8 @@ public class AuthenticationService {
         List<UserRoles> currentRoles = currentUser.get().getValue();
 
         var authRole = UserRoles.valueOf(authorizedLevelRole.trim());
-        boolean isAuthRoleHigherThanAnyPresent = currentRoles.stream().allMatch(curRole->authRole.ordinal()>curRole.ordinal());
-        if(isAuthRoleHigherThanAnyPresent){return false;}
-        return true;
+        boolean isAuthRoleHigherThanAnyPresent = currentRoles.stream().allMatch(curRole->curRole.ordinal()>=authRole.ordinal());
+        if(isAuthRoleHigherThanAnyPresent){return true;}
+        return false;
     }
 }

--- a/backend/src/main/java/com/revature/project2/services/TransactionService.java
+++ b/backend/src/main/java/com/revature/project2/services/TransactionService.java
@@ -69,6 +69,8 @@ public class TransactionService {
         if (newCategory == null || newCategory.isEmpty()) {
             throw new BusinessException(607,"Transaction category cannot be null or empty");
         }
+
+
         transaction.setCategory(newCategory);
         return transactionRepository.save(transaction);
     }
@@ -82,5 +84,7 @@ public class TransactionService {
             return ResponseEntity.ok(transactions);
         }
     }
+
+    
 
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 spring.application.name=project2
 
 # Database credentials
-#spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
-spring.datasource.url = jdbc:postgresql://project2demodb.czw4qucige57.us-east-2.rds.amazonaws.com:5432/postgres
+spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
+#spring.datasource.url = jdbc:postgresql://project2demodb.czw4qucige57.us-east-2.rds.amazonaws.com:5432/postgres
 spring.datasource.username = postgres
 spring.datasource.password = password
 

--- a/backend/src/test/java/com/revature/project2/AuthentificationServiceTests.java
+++ b/backend/src/test/java/com/revature/project2/AuthentificationServiceTests.java
@@ -11,6 +11,8 @@ import com.revature.project2.services.AuthenticationService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.security.core.Authentication;
@@ -164,14 +166,26 @@ public class AuthentificationServiceTests {
         Assertions.assertTrue(returnObj.isEmpty());
     }
 
-    @Test
-    public void test_validateCurrentUserRole(){
+    @ParameterizedTest
+    @CsvSource({"ROLE_EMPLOYEE, ROLE_EMPLOYEE, true",
+            "ROLE_EMPLOYEE, ROLE_MANAGER, false",
+            "ROLE_MANAGER, ROLE_EMPLOYEE, true",
+            "ROLE_MANAGER, ROLE_MANAGER, true"})
+    public void test_validateCurrentUserRole(String userRole, String authRole, String resultString){
+        boolean result = Boolean.valueOf(resultString);
 
-        User user = new User("User","passwordEncoded", "user@user.com","user_fn","user_ln","ROLE_EMPLOYEE");
+        User user = new User("User","passwordEncoded", "user@user.com","user_fn","user_ln",userRole);
         when(passwordEncoder.encode("passwordEncoded")).thenReturn("password");
         UserDetails userDetails = new CustomUserDetails(user, passwordEncoder);
 
-        Authentication authentication = new JWTAuthObj("anonymousUser", true, userDetails.getAuthorities() );
+        Authentication authentication = new JWTAuthObj("User", true, userDetails.getAuthorities() );
+
+        SecurityContext securityContext = Mockito.mock(SecurityContext.class);
+        SecurityContextHolder.setContext(securityContext);
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+
+        Assertions.assertTrue(authenticationService.validateCurrentUserRole(authRole)==result);
+
 
     }
 

--- a/backend/src/test/java/com/revature/project2/AuthentificationServiceTests.java
+++ b/backend/src/test/java/com/revature/project2/AuthentificationServiceTests.java
@@ -164,4 +164,15 @@ public class AuthentificationServiceTests {
         Assertions.assertTrue(returnObj.isEmpty());
     }
 
+    @Test
+    public void test_validateCurrentUserRole(){
+
+        User user = new User("User","passwordEncoded", "user@user.com","user_fn","user_ln","ROLE_EMPLOYEE");
+        when(passwordEncoder.encode("passwordEncoded")).thenReturn("password");
+        UserDetails userDetails = new CustomUserDetails(user, passwordEncoder);
+
+        Authentication authentication = new JWTAuthObj("anonymousUser", true, userDetails.getAuthorities() );
+
+    }
+
 }


### PR DESCRIPTION
Added support for managers auditing transactions which makes them impossible to modify. 
Added tests and controller endpoint for this and all supporting functions. 

Did not add managers viewing users records and such, but the support function I added will make that much easier. 
